### PR TITLE
enable jetifier

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,6 +14,7 @@ org.gradle.jvmargs=-Xmx2048m
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app"s APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
+android.enableJetifier=true
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official


### PR DESCRIPTION
The cardinal SDK being used requires that we use jetifier to not see a runtime crash.