### PR TITLE
Fix return URL with appended ://paypalpay

### DIFF
--- a/quickstart-kotlin/src/main/java/com/paypal/checkoutsamples/QuickStartApp.kt
+++ b/quickstart-kotlin/src/main/java/com/paypal/checkoutsamples/QuickStartApp.kt
@@ -23,7 +23,7 @@ class QuickStartApp : Application() {
                     loggingEnabled = true,
                     shouldFailEligibility = false
                 ),
-                returnUrl = BuildConfig.LIBRARY_PACKAGE_NAME
+                returnUrl = BuildConfig.LIBRARY_PACKAGE_NAME + "://paypalpay"
             )
         )
     }


### PR DESCRIPTION
An error was thrown when starting the SDK due to the return URL missing `://paypalpay`.